### PR TITLE
Fixed so that store is updated when origin is unmounted

### DIFF
--- a/lib/origin.js
+++ b/lib/origin.js
@@ -37,8 +37,7 @@ var Origin = function (_Component) {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       // hide the tooltip
-      var action = (0, _actions.hide)(_extends({}, this.props));
-      this.props.dispatch(action);
+      this.props.dispatch((0, _actions.hide)(_extends({}, this.props)));
     }
   }, {
     key: 'createWithDelay',

--- a/lib/origin.js
+++ b/lib/origin.js
@@ -34,6 +34,13 @@ var Origin = function (_Component) {
   }
 
   _createClass(Origin, [{
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      // hide the tooltip
+      var action = (0, _actions.hide)(_extends({}, this.props));
+      this.props.dispatch(action);
+    }
+  }, {
     key: 'createWithDelay',
     value: function createWithDelay(creator) {
       var extras = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];

--- a/src/origin.js
+++ b/src/origin.js
@@ -59,6 +59,11 @@ class Origin extends Component {
     return connect()(CustomOrigin);
   }
 
+  componentWillUnmount(){
+    // hide the tooltip
+    this.props.dispatch(hide({ ...this.props }));
+  }
+
   createWithDelay(creator, extras = {}) {
     const { delay: duration, onTimeout: callback } = this.props;
     let action = creator({ ...this.props, ...extras });


### PR DESCRIPTION
Found that when tool tip origin is a clickable that opens another component, after closing the component, the tool tip is still set to 'show' and is rendered at the upper left corner of the screen.  It is not reset until you hover over the origin again.  Added componentWillUnmount that dispatches the 'hide' action.  