### PR TITLE
Enable ReduxDevTools extension by modifying how store is created in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ npm start
 
 Open `http://localhost:8080/webpack-dev-server/` for auto-reloading.
 If you want to debug with React Dev Tools, `http://localhost:8080/` will be preferred.
+You can also view the store, and see the actions being fired, if you have [Redux DevTools extension](https://github.com/zalmoxisus/redux-devtools-extension) installed.
 
 ### Run test
 

--- a/examples/common/store.js
+++ b/examples/common/store.js
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import reducer from './reducers';
 import logger from 'redux-logger';
 import { middleware as tooltip } from '../../src/index';
@@ -8,4 +8,7 @@ if (window && !window.__karma__) {
   list.push(logger());
 }
 
-export default applyMiddleware(...list)(createStore)(reducer);
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(reducer, composeEnhancers(applyMiddleware(...list)));
+
+export default store;


### PR DESCRIPTION
This should solve #38!

Now developers can instantly understand what actions are being fired and how the state changes.