### PR TITLE
Fix redux-devtools-extension lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ In most cases, you may use this component without any options.
 For advanced usage, you can override the default handlers; `onMouseEnter` and `onMouseLeave`.
 
 + `name` *(`string`|`string[]`)*: A name(s) to specify which tooltip(s) should be used.
++ `id` *(`string`)*: An unique identifier that will be used for tracking when storing a DOM node into the redux store is an issue (e.g using [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension))
 + `content` *(`string`|`DOM`|`DOM[]`)*: A content for tooltip. If string, it's sanitized by [DOMPurify](https://github.com/cure53/DOMPurify).
 + `place` *(`string`|`string[]`)*: A name of direction to specify a location of tooltip.
 + `tagName` *(`string`)*: A tag name of wrapper element. Default is `span`.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ In most cases, you may use this component without any options.
 For advanced usage, you can override the default handlers; `onMouseEnter` and `onMouseLeave`.
 
 + `name` *(`string`|`string[]`)*: A name(s) to specify which tooltip(s) should be used.
-+ `id` *(`string`)*: An unique identifier that will be used for tracking when storing a DOM node into the redux store is an issue (e.g using [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension))
 + `content` *(`string`|`DOM`|`DOM[]`)*: A content for tooltip. If string, it's sanitized by [DOMPurify](https://github.com/cure53/DOMPurify).
 + `place` *(`string`|`string[]`)*: A name of direction to specify a location of tooltip.
 + `tagName` *(`string`)*: A tag name of wrapper element. Default is `span`.

--- a/src/origin.js
+++ b/src/origin.js
@@ -64,12 +64,14 @@ class Origin extends Component {
 
   componentWillUnmount(){
     // hide the tooltip
-    this.props.dispatch(hide({ ...this.props }));
+    const props = blacklist(this.props, 'children')
+    this.props.dispatch(hide({...props}));
   }
 
   createWithDelay(creator, extras = {}) {
     const { delay: duration, onTimeout: callback } = this.props;
-    let action = creator({ ...this.props, ...extras });
+    const props = blacklist(this.props, 'children')
+    let action = creator({ ...props, ...extras });
     if (duration || callback) {
       action = delay(action, { duration, callback });
     }
@@ -81,9 +83,10 @@ class Origin extends Component {
 
     if (!props.onMouseEnter) {
       props.onMouseEnter = e => {
+        const props = blacklist(this.props, 'children')
         const action = ['show', 'both'].indexOf(this.props.delayOn) !== -1
-          ? this.createWithDelay(show, { origin: e.target })
-          : show({ ...this.props, origin: e.target });
+          ? this.createWithDelay(show, { origin: e.target.id || e.target })
+          : show({ ...props, origin: e.target.id || e.target });
         this.props.dispatch(action);
         this.props.onHover && this.props.onHover(e);
       };
@@ -91,9 +94,10 @@ class Origin extends Component {
 
     if (!props.onMouseLeave) {
       props.onMouseLeave = e => {
+        const props = blacklist(this.props, 'children')
         const action = ['hide', 'both'].indexOf(this.props.delayOn) !== -1
           ? this.createWithDelay(hide)
-          : hide({ ...this.props });
+          : hide({...props});
         this.props.dispatch(action);
         this.props.onLeave && this.props.onLeave(e);
       };

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -15,7 +15,9 @@ class Tooltip extends Component {
     return {
       // Props from state tree
       show: PropTypes.bool.isRequired,
-      origin: PropTypes.object,
+      origin: PropTypes.oneOfType([
+        PropTypes.object, PropTypes.string
+      ]),
       el: PropTypes.object,
       place: PropTypes.oneOfType([
         PropTypes.string, PropTypes.array

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,14 +34,19 @@ export function position(el) {
  *
  * @param {string} place - 'top', 'right', 'bottom', or 'left'.
  * @param {Object} content - DOM element that contains a content.
- * @param {Object} origin - DOM element or position object.
+ * @param {Object} origin - DOM element, element id or position object.
  * @return {Object} contains 'top', 'left', and extra keys.
  */
 export function placement(place, content, origin) {
   const gap = 12;
   const dim = dimension(content);
-  const pos = isDOM(origin) ? position(origin)
-    : { top: origin.y, right: origin.x, bottom: origin.y, left: origin.x, width: 0, height: 0 };
+  let pos = { top: origin.y, right: origin.x, bottom: origin.y, left: origin.x, width: 0, height: 0 }
+
+  if (isDOM(origin)) {
+    pos = position(origin)
+  } else if (typeof origin === 'string') {
+    pos = position(document.getElementById(origin))
+  }
 
   let offset = { width: dim.width, height: dim.height };
   switch(place) {


### PR DESCRIPTION
[redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) (inspector mainly) was hanging several seconds when wrapping `<Origin>` around a svg element. The cause was that `SHOW` and `HIDE` actions payloads were bloated with `Origin.props.children` and `e.target`.

So I removed children from payload and used an id referencing the DOM element as origin so we can retrieve the DOM node when we need it only.

Update: maybe it'd be best to generate the id for the DOM origin element at runtime instead of letting the user figure it out.