### PR TITLE
Add prop-types package and upgrade react dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "blacklist": "^1.1.4",
     "dompurify": "^0.8.4",
-    "is-dom": "^1.0.5"
+    "is-dom": "^1.0.5",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -58,9 +59,9 @@
     "mocha": "^3.2.0",
     "phantomjs-prebuilt": "^2.1.14",
     "power-assert": "^1.4.2",
-    "react": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^15.6.2",
+    "react-addons-test-utils": "^15.6.2",
+    "react-dom": "^15.6.2",
     "react-redux": "^5.0.1",
     "redux": "^3.6.0",
     "redux-logger": "^2.7.4",

--- a/src/origin.js
+++ b/src/origin.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import blacklist from 'blacklist';
 import { show, hide, delay } from './actions';

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import { sanitize } from 'dompurify';


### PR DESCRIPTION
`redux-tooltip` doesn't work with React 16 because `PropTypes` is to longer available as part of the react package. This PR adds the `prop-types` package, updates the react dependencies to 15.6.2, and updates the components that use `PropTypes`.